### PR TITLE
add github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+<!--
+
+Have you read CoronaTracker's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect
+
+-->
+
+### Prerequisites
+
+* [ ] Put an X between the brackets on this line if you have done all of the following:
+    * Reproduced the problem in QA
+    * Followed all applicable steps in the TROUBLESHOOTING guide: TODO
+    * Checked for relevant discussions on Discord: <https://discord.gg/pPERUuv>
+    * Checked that your issue isn't already filed: <https://github.com/COVID-19-electronic-health-system/Corona-tracker/issues>
+
+### Description
+
+<!-- Description of the issue -->
+
+### Steps to Reproduce
+
+1. <!-- First Step -->
+2. <!-- Second Step -->
+3. <!-- and so on… -->
+
+**Expected behavior:**
+
+<!-- What you expect to happen -->
+
+**Actual behavior:**
+
+<!-- What actually happens -->
+
+**Reproduces how often:**
+
+<!-- What percentage of the time does it reproduce? -->
+
+### Versions
+
+<!-- TODO -->
+
+### Additional Information
+
+<!-- Any additional information, configuration or data that might be necessary to reproduce the issue. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+<!--
+
+Have you read CoronaTracker's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect -->
+
+## Summary
+
+<!-- One paragraph explanation of the feature. -->
+
+## Motivation
+
+<!-- Why are we doing this? What use cases does it support? What is the expected outcome? -->
+
+## Describe alternatives you've considered
+
+<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why Atom's existing customizability isn't suitable for this feature. -->
+
+## Additional context
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/stand_up_meeting .md
+++ b/.github/ISSUE_TEMPLATE/stand_up_meeting .md
@@ -1,0 +1,25 @@
+---
+name: stand up meeting
+about: Stand up meeting topics
+
+---
+
+<!--
+
+Have you read CoronaTracker's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect -->
+
+## Summary
+
+<!-- One paragraph explanation of the Stand up meeting topics to discuss. -->
+
+## Motivation
+
+<!-- Why are we doing this? What use cases does it support? What is the expected outcome? -->
+
+## Describe alternatives you've considered
+
+<!-- A clear and concise description of the alternative solutions you've considered. -->
+
+## Additional context
+
+<!-- Add any other context or screenshots about the meeting issues here. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## IMPORTANT: Please do not create a Pull Request without creating an issue first.
+
+**Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.**
+
+**Do not change the following line aside from replacing YOUR-ISSUE-HERE with the issue this PR fixes** 
+
+fixes #YOUR-ISSUE-HERE
+
+### Please provide enough information so that others can review your pull request:
+
+### Explain the **details** for making this change. What existing problem does the pull request solve?
+
+### Test plan (required)
+
+Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
+
+<!-- Make sure tests pass on both Travis and Circle CI. -->
+
+### Final Checklist
+
+- [ ] Have you bumped the version in `package.json`?
+    - Second decimal for major change, third decimal for minor change. This can go past 10 i.e. 1.0.9 !=> 1.1.0, 1.0.9 => 1.0.10
+    - [Read here for more info](https://semver.org/)
+- [ ] Have you added any new tests necessary?
+- [ ] Is your PR rebased off the most current master?
+- [ ] Have you squashed all commits, or if you will merge will you squash all commits?
+- [ ] Did you use yarn, not npm?
+- [ ] Did you use Material-UI wherever possible?
+- [ ] Did you format according to Prettier?
+- [ ] Did you run all of your most recent changes locally to make sure everything is working?


### PR DESCRIPTION
Fixes #6 

Adds GitHub templates being used in CoronaTracker in order to make things flow more smoothly - this is a jumping-off point, we can always revise to fit the needs of `Coronalytics` itself 